### PR TITLE
Allow PHP 7.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "webgriffe/module-bootstrap-menu",
     "description": "Magento 2 module which turns top menu compatible with Bootstrap.",
     "require": {
-        "php": "^5.6|^7.0|^7.1",
+        "php": "^5.6|^7.0|^7.1|^7.2",
         "magento/module-theme": "100.1.*|100.2.*"
     },
     "suggest": {


### PR DESCRIPTION
Allow usage of PHP 7.2 which will be supported in Magento 2.3.