### PR TITLE
Remove version requirement as per 2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Magento 2 module which turns top menu compatible with Bootstrap.",
     "require": {
         "php": "^5.6|^7.0|^7.1|^7.2",
-        "magento/module-theme": "100.1.*|100.2.*"
+        "magento/module-theme": "*"
     },
     "suggest": {
         "webgriffe/theme-frontend-bootstrap": "^1.0"


### PR DESCRIPTION
Specified version of module is now removed in Magento 2.3. This will allow it to install.